### PR TITLE
ci: fix broken CI when no new version is available

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,7 @@ jobs:
       - uses: sigstore/cosign-installer@v3.3.0
 
       - name: Image Signing
+        if: ${{ steps.version.outputs.VERSION != ''}}
         run: |
           cosign sign --yes \
           -a "repo=${{ github.repository }}" \

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -5,7 +5,6 @@ repositoryUrl: https://github.com/spectrocloud/hello-universe-api
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
-  - "@semantic-release/changelog"
   - - "@semantic-release/exec"
     - analyzeCommitsCmd: echo 'NEW_VERSION=false' > VERSION.env
       verifyReleaseCmd: |-
@@ -14,5 +13,3 @@ plugins:
   - - "@semantic-release/github"
     - assets:
         - "*.zip"
-  - - "@semantic-release/npm"
-    - npmPublish: false


### PR DESCRIPTION
## Describe the Change

This PR fixes the CI so that no build push is attempted when no new versions are available. 

